### PR TITLE
Adjust Elasticsearch cluster setup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,9 +5,9 @@ This is a Docker setup for the Elastic stack, useful to demonstrate examples in 
 The following Docker containers are available
 
 * Elasticsearch instances (7.8.1), a three node cluster, accessible from host, most examples only require first instance
-  * http://localhost:9200 (main)
-  * http://localhost:9201
-  * http://localhost:9202
+  * http://localhost:9200 (master, data)
+  * http://localhost:9201 (data)
+  * http://localhost:9202 (data)
 * [cerebro](http://localhost:9000/#/overview?host=http:%2F%2Felasticsearch01:9200)
 * curator (for index management)
 * filebeat (to generate logs)
@@ -17,6 +17,8 @@ The following Docker containers are available
 * redis (acts as a buffer between filebeat & logstash)
 
 For more details check `docker-compose.yml` configuration. Most examples in a workshop only require a single Elasticsearch node.
+
+> The main reason that `elasticsearch01` is the *only* `master` node is that it allows to start this container as a single node cluster. When starting containers `elasticsearch02` and `elasticsearch03` afterwards it does not set the *minimum* of master nodes from `1` to `2`. This is mainly for presentation purposes and is not recommended in a **production** environment where all instances in a 3 nodes cluster should have the `master` role.
 
 
 ## Setup
@@ -44,12 +46,27 @@ These services can be accessed via web browser.
 * [Cerebro](http://localhost:9000/#/overview?host=http:%2F%2Felasticsearch01:9200)
 * [Kibana](http://localhost:5601) (when Docker container is built and started)
 
-**Note** Some examples may require to start other containers as well.
-To start these containers run `docker-compose up --build`, wait until all Docker containers are built.
+> **!** Some examples may require to start other containers as well.
+
+For example to start all 3 Elasticsearch nodes as a cluster run
+
+```bash
+docker-compose up -d --build elasticsearch01 elasticsearch02 elasticsearch03
+```
+
+To remove all containers and their volumes use the following Docker Compose command:
+
+```bash
+docker-compose down -v --remove-orphans
+```
+
+> This removes all Docker containers and all the data folders defined in the `docker-compose.yml`. This is useful when the cluster has seen at least one additional *master* node and may not start as a single node cluster afterwards.
 
 
 ## References
 
+* [Elasticsearch Bootstrapping a Cluster](https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-discovery-bootstrap-cluster.html)
+* [Elasticsearch Resilience in Small Clusters](https://www.elastic.co/guide/en/elasticsearch/reference/current/high-availability-cluster-small-clusters.html)
 * [Elasticsearch Docker Setup](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/docker.html)
 * [3 Node Elasticsearch Cluster with Docker](https://blog.ruanbekker.com/blog/2018/04/29/running-a-3-node-elasticsearch-cluster-with-docker-compose-on-your-laptop-for-testing/)
 

--- a/containers/curator/Dockerfile
+++ b/containers/curator/Dockerfile
@@ -1,11 +1,12 @@
 FROM python:3.8-alpine
 
 RUN apk --no-cache add curl
+
+RUN pip install "boto3<1.16" "botocore<1.19"
+
 RUN pip install elasticsearch-curator==5.8.1 &&\
     rm -rf /var/cache/apk/*
 
-COPY ./config/ /config
+COPY ./config /config
 
-RUN /usr/bin/crontab /config/crontab.txt
-
-CMD ["/usr/sbin/crond","-f"]
+WORKDIR /config

--- a/containers/curator/config/crontab.txt
+++ b/containers/curator/config/crontab.txt
@@ -1,1 +1,1 @@
-0 0 * * * curator --config /config/config.yml /config/delete_indices_action.yml
+0 0 * * * curator --config /config/config.yml /config/delete_indices.yml

--- a/containers/curator/config/delete_indices.yml
+++ b/containers/curator/config/delete_indices.yml
@@ -1,3 +1,4 @@
+# delete_indices.yml
 ---
 actions:
   1:

--- a/containers/curator/config/index_rotate.yml
+++ b/containers/curator/config/index_rotate.yml
@@ -1,0 +1,47 @@
+---
+actions:
+  1:
+    action: allocation
+    description: >-
+      Apply shard allocation filtering rules to logstash-* prefixed indices that are
+      older than 1 day. These indices will move their shards from hot to warm nodes.
+    options:
+      key: data
+      value: warm
+      allocation_type: require
+      wait_for_completion: true
+      ignore_empty_list: True
+      timeout_override:
+      continue_if_exception: True
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 1
+  2:
+    action: forcemerge
+    description: >-
+      Performs a force merge operation on logstash-* prefixed indices that are older than 2 days. At this point these should be read only, it's best to avoid writing to these indices once optimized.
+    options:
+      max_num_segments: 1
+      delay:
+      ignore_empty_list: True
+      timeout_override: 21600
+      continue_if_exception: False
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: days
+      unit_count: 1

--- a/containers/curator/config/rollover.yml
+++ b/containers/curator/config/rollover.yml
@@ -1,0 +1,21 @@
+---
+actions:
+  1:
+    action: rollover
+    description: >-
+      Rollover the index associated with alias 'rollover', with format "rollover-00000x" or
+      using prefix-YYYY.MM.DD-1.
+    options:
+      # Alias name
+      name: rollover
+      conditions:
+        max_age: 2d
+        max_docs: 5
+        max_size: 100mb
+      extra_settings:
+        # some index settings can be set here
+        index.number_of_shards: 2
+        index.number_of_replicas: 1
+      timeout_override:
+      continue_if_exception: False
+      disable_action: False

--- a/containers/curator/config/snapshot.yml
+++ b/containers/curator/config/snapshot.yml
@@ -1,0 +1,18 @@
+---
+actions:
+  1:
+    action: snapshot
+    description: >-
+      Snap shots all prefix based 'logstash-*' indices.
+    options:
+      repository: logstash_backup_repository
+      name: logstash-snapshots
+      wait_for_completion: True
+      max_wait: 3600
+      wait_interval: 10
+      continue_if_exception: True
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-

--- a/containers/elasticsearch01/elasticsearch.yml
+++ b/containers/elasticsearch01/elasticsearch.yml
@@ -5,17 +5,14 @@ node.master: true
 node.data: true
 node.ingest: true
 
-path.repo: /tmp
 path.data: /usr/share/elasticsearch/data
 
-# See https://www.elastic.co/guide/en/elasticsearch/reference/7.0/modules-discovery-bootstrap-cluster.html
-# for more details
-discovery.seed_hosts:
-  - elasticsearch01:9300
-  # - elasticsearch02:9300
-  # - elasticsearch03:9300
+# discovery.seed_hosts:
+#   - elasticsearch01:9300
 
 cluster.initial_master_nodes:
-  - elasticsearch01
-  # - elasticsearch02
-  # - elasticsearch03
+  - elasticsearch01:9200
+
+# define hot node
+node.attr.data: hot
+node.attr.zone: zone1

--- a/containers/elasticsearch01/elasticsearch.yml
+++ b/containers/elasticsearch01/elasticsearch.yml
@@ -5,13 +5,8 @@ node.master: true
 node.data: true
 node.ingest: true
 
-path.data: /usr/share/elasticsearch/data
-
-# discovery.seed_hosts:
-#   - elasticsearch01:9300
-
 cluster.initial_master_nodes:
-  - elasticsearch01:9200
+  - elasticsearch01
 
 # define hot node
 node.attr.data: hot

--- a/containers/elasticsearch02/elasticsearch.yml
+++ b/containers/elasticsearch02/elasticsearch.yml
@@ -8,5 +8,8 @@ node.ingest: true
 cluster.initial_master_nodes:
   - elasticsearch01
 
+discovery.seed_hosts:
+  - elasticsearch01
+
 node.attr.data: warm
 node.attr.zone: zone1

--- a/containers/elasticsearch02/elasticsearch.yml
+++ b/containers/elasticsearch02/elasticsearch.yml
@@ -5,13 +5,6 @@ node.master: false
 node.data: true
 node.ingest: true
 
-path.data: /usr/share/elasticsearch/data
-
-discovery.seed_hosts:
-  - elasticsearch01:9300
-#  - elasticsearch02:9300
-#  - elasticsearch03:9300
-
 cluster.initial_master_nodes:
   - elasticsearch01
 

--- a/containers/elasticsearch02/elasticsearch.yml
+++ b/containers/elasticsearch02/elasticsearch.yml
@@ -1,7 +1,7 @@
 network.host: 0.0.0.0
 
 node.name: elasticsearch02
-node.master: true
+node.master: false
 node.data: true
 node.ingest: true
 
@@ -12,7 +12,8 @@ discovery.seed_hosts:
 #  - elasticsearch02:9300
 #  - elasticsearch03:9300
 
-#cluster.initial_master_nodes:
-#  - elasticsearch01
-#  - elasticsearch02
-#  - elasticsearch03
+cluster.initial_master_nodes:
+  - elasticsearch01
+
+node.attr.data: warm
+node.attr.zone: zone1

--- a/containers/elasticsearch03/elasticsearch.yml
+++ b/containers/elasticsearch03/elasticsearch.yml
@@ -8,5 +8,8 @@ node.ingest: true
 cluster.initial_master_nodes:
   - elasticsearch01
 
+discovery.seed_hosts:
+  - elasticsearch01
+
 node.attr.data: warm
 node.attr.zone: zone2

--- a/containers/elasticsearch03/elasticsearch.yml
+++ b/containers/elasticsearch03/elasticsearch.yml
@@ -5,11 +5,6 @@ node.master: false
 node.data: true
 node.ingest: true
 
-path.data: /usr/share/elasticsearch/data
-
-discovery.seed_hosts:
-  - elasticsearch01:9300
-
 cluster.initial_master_nodes:
   - elasticsearch01
 

--- a/containers/elasticsearch03/elasticsearch.yml
+++ b/containers/elasticsearch03/elasticsearch.yml
@@ -1,7 +1,7 @@
 network.host: 0.0.0.0
 
 node.name: elasticsearch03
-node.master: true
+node.master: false
 node.data: true
 node.ingest: true
 
@@ -9,10 +9,9 @@ path.data: /usr/share/elasticsearch/data
 
 discovery.seed_hosts:
   - elasticsearch01:9300
-#  - elasticsearch02:9300
-#  - elasticsearch03:9300
 
-# cluster.initial_master_nodes:
-#   - elasticsearch01
-#   - elasticsearch02
-#   - elasticsearch03
+cluster.initial_master_nodes:
+  - elasticsearch01
+
+node.attr.data: warm
+node.attr.zone: zone2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.routing.allocation.awareness.attributes=zone
       - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
+      - path.data=/usr/share/elasticsearch/data
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
@@ -101,6 +102,7 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.routing.allocation.awareness.attributes=zone
       - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
+      - path.data=/usr/share/elasticsearch/data
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
@@ -129,6 +131,7 @@ services:
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.routing.allocation.awareness.attributes=zone
       - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
+      - path.data=/usr/share/elasticsearch/data
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
       - node.attr.data=hot
       - node.attr.zone=zone1
       - node.name=elasticsearch01
-      - node.roles=data,ingest,master
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
@@ -114,7 +113,6 @@ services:
       - node.attr.data=warm
       - node.attr.zone=zone1
       - node.name=elasticsearch02
-      - node.roles=data,ingest,master
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
@@ -149,7 +147,6 @@ services:
       - node.attr.data=warm
       - node.attr.zone=zone2
       - node.name=elasticsearch03
-      - node.roles=data,ingest,master
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,7 @@ services:
     container_name: elasticsearch01
     volumes:
       - esdata1:/usr/share/elasticsearch/data
+      - esrepo:/usr/share/elasticsearch/repos
     ports:
       - 9200:9200
       - 9300:9300
@@ -67,8 +68,19 @@ services:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
       - cluster.routing.allocation.disk.threshold_enabled=false
-      - http.cors.enabled=true
-      - http.cors.allow-origin=*
+      # - http.cors.enabled=true
+      # - http.cors.allow-origin=*
+      - cluster.initial_master_nodes=elasticsearch01
+      - cluster.routing.allocation.awareness.attributes=zone
+      - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
+      - discovery.seed_hosts=elasticsearch01:9300
+      - network.host=0.0.0.0
+      # define hot node
+      - node.attr.data=hot
+      - node.attr.zone=zone1
+      - node.name=elasticsearch01
+      - node.roles=data,ingest,master
+      - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
       memlock:
@@ -77,53 +89,75 @@ services:
     networks:
       - esnet
 
-  # elasticsearch02:
-  #   build:
-  #     context: containers/elasticsearch02
-  #     dockerfile: Dockerfile
-  #   container_name: elasticsearch02
-  #   volumes:
-  #     - esdata2:/usr/share/elasticsearch/data
-  #   ports:
-  #     - 9201:9200
-  #     - 9301:9300
-  #   environment:
-  #     - cluster.name=docker-cluster
-  #     - bootstrap.memory_lock=true
-  #     - cluster.routing.allocation.disk.threshold_enabled=false
-  #     - http.cors.enabled=true
-  #     - http.cors.allow-origin=*
-  #     - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
-  #   ulimits:
-  #     memlock:
-  #       soft: -1
-  #       hard: -1
-  #   networks:
-  #     - esnet
+  elasticsearch02:
+    build:
+      context: containers/elasticsearch02
+      dockerfile: Dockerfile
+    container_name: elasticsearch02
+    volumes:
+      - esdata2:/usr/share/elasticsearch/data
+      - esrepo:/usr/share/elasticsearch/repos
+    ports:
+      - 9201:9200
+      - 9301:9300
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.routing.allocation.awareness.attributes=zone
+      - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
+      - discovery.seed_hosts=elasticsearch01:9300
+      # - http.cors.enabled=true
+      # - http.cors.allow-origin=*
+      - network.host=0.0.0.0
+       # define warm node
+      - node.attr.data=warm
+      - node.attr.zone=zone1
+      - node.name=elasticsearch02
+      - node.roles=data,ingest,master
+      - path.repo=/usr/share/elasticsearch/repos
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    networks:
+      - esnet
 
-  # elasticsearch03:
-  #   build:
-  #     context: containers/elasticsearch03
-  #     dockerfile: Dockerfile
-  #   container_name: elasticsearch03
-  #   volumes:
-  #     - esdata3:/usr/share/elasticsearch/data
-  #   ports:
-  #     - 9202:9200
-  #     - 9302:9300
-  #   environment:
-  #     - cluster.name=docker-cluster
-  #     - bootstrap.memory_lock=true
-  #     - cluster.routing.allocation.disk.threshold_enabled=false
-  #     - http.cors.enabled=true
-  #     - http.cors.allow-origin=*
-  #     - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
-  #   ulimits:
-  #     memlock:
-  #       soft: -1
-  #       hard: -1
-  #   networks:
-  #     - esnet
+  elasticsearch03:
+    build:
+      context: containers/elasticsearch03
+      dockerfile: Dockerfile
+    container_name: elasticsearch03
+    volumes:
+      - esdata3:/usr/share/elasticsearch/data
+      - esrepo:/usr/share/elasticsearch/repos
+    ports:
+      - 9202:9200
+      - 9302:9300
+    environment:
+      - cluster.name=docker-cluster
+      - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.routing.allocation.awareness.attributes=zone
+      - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
+      - discovery.seed_hosts=elasticsearch01:9300
+      # - http.cors.enabled=true
+      # - http.cors.allow-origin=*
+      - network.host=0.0.0.0
+       # define another warm node
+      - node.attr.data=warm
+      - node.attr.zone=zone2
+      - node.name=elasticsearch03
+      - node.roles=data,ingest,master
+      - path.repo=/usr/share/elasticsearch/repos
+      - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    networks:
+      - esnet
 
   metricbeat:
     build:
@@ -166,6 +200,8 @@ volumes:
   esdata2:
     driver: local
   esdata3:
+    driver: local
+  esrepo:
     driver: local
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,18 +67,12 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
-      - cluster.routing.allocation.disk.threshold_enabled=false
+      # - discovery.type=single-node
       # - http.cors.enabled=true
       # - http.cors.allow-origin=*
-      - cluster.initial_master_nodes=elasticsearch01
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.routing.allocation.awareness.attributes=zone
       - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
-      - discovery.seed_hosts=elasticsearch01:9300
-      - network.host=0.0.0.0
-      # define hot node
-      - node.attr.data=hot
-      - node.attr.zone=zone1
-      - node.name=elasticsearch01
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
@@ -102,17 +96,11 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
+      # - http.cors.enabled=true
+      # - http.cors.allow-origin=*
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.routing.allocation.awareness.attributes=zone
       - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
-      - discovery.seed_hosts=elasticsearch01:9300
-      # - http.cors.enabled=true
-      # - http.cors.allow-origin=*
-      - network.host=0.0.0.0
-       # define warm node
-      - node.attr.data=warm
-      - node.attr.zone=zone1
-      - node.name=elasticsearch02
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:
@@ -136,17 +124,11 @@ services:
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
+      # - http.cors.enabled=true
+      # - http.cors.allow-origin=*
       - cluster.routing.allocation.disk.threshold_enabled=false
       - cluster.routing.allocation.awareness.attributes=zone
       - cluster.routing.allocation.awareness.force.zone.values=zone1,zone2
-      - discovery.seed_hosts=elasticsearch01:9300
-      # - http.cors.enabled=true
-      # - http.cors.allow-origin=*
-      - network.host=0.0.0.0
-       # define another warm node
-      - node.attr.data=warm
-      - node.attr.zone=zone2
-      - node.name=elasticsearch03
       - path.repo=/usr/share/elasticsearch/repos
       - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
     ulimits:


### PR DESCRIPTION

This adjusts the Elasticsearch cluster to only have a single `master-eligible` node (for now). The main reason is most examples / exercises only require a single node running, a few require all three nodes. If all nodes are `master-eligible` the **minimum** master nodes setting is increased from `1` to `2`. Starting a single node cluster again does not boot correctly afterwards, because the cluster assumes then a minimum of 2 nodes. To avoid this issue for now and allow both setups to run both containers `elasticsearch02` and `elasticsearch03` are not `master-eligible`.

Another way to solve this would to delete all mounted data folders from these containers in order to remove this information, but this seems a bit more destructive then necessary for any presentation.

* update Elasticsearch `Dockerfile` settings to assign roles, master nodes and seeds correctly
* re-enable `elasticsearch02` and `elasticsearch03` in `docker-compose.yml`
* add links to Elasticsearch documentation regarding cluster setup to Readme
* add a few useful Docker Compose commands to Readme
* fix curator `Dockerfile` to build correctly
* add a few Curator action files as examples to `curator` container
* add `path.repo` setting to all Elasticsearch containers, it's a shared mounted folder for backups